### PR TITLE
Add virtual destructor to NetworkAddress.

### DIFF
--- a/NetworkSocket.cpp
+++ b/NetworkSocket.cpp
@@ -292,7 +292,7 @@ void NetworkSocketTCPObfuscated::Receive(NetworkPacket *packet){
 	}
 
 	if(packetLen>packet->length){
-		LOGW("packet too big to fit into buffer (%u vs %u)", packetLen, packet->length);
+		LOGW("packet too big to fit into buffer (%u vs %u)", (unsigned int)packetLen, (unsigned int)packet->length);
 		packet->length=0;
 		return;
 	}

--- a/NetworkSocket.h
+++ b/NetworkSocket.h
@@ -28,6 +28,7 @@ namespace tgvoip {
 		virtual std::string ToString()=0;
 		bool operator==(const NetworkAddress& other);
 		bool operator!=(const NetworkAddress& other);
+		virtual ~NetworkAddress()=default;
 	};
 
 	class IPv4Address : public NetworkAddress{


### PR DESCRIPTION
Subclasses of NetworkAddress are deleted using pointers to the base class,
so a virtual destructor is required. Also fix a couple of warnings on 64bit.