### PR TITLE
libtgvoip: use SSE2 cflags only in supported archs

### DIFF
--- a/libtgvoip.gyp
+++ b/libtgvoip.gyp
@@ -381,8 +381,12 @@
               'defines': [
                 'WEBRTC_POSIX',
               ],
-              'cflags_cc': [
-                '-msse2',
+              'conditions': [
+                [ '"<!(uname -p)" == "x86_64" or "<!(uname -p)" == "i686"', {
+                  'cflags_cc': [
+                    '-msse2',
+                  ],
+                }]
               ],
               'direct_dependent_settings': {
                 'libraries': [

--- a/libtgvoip.gyp
+++ b/libtgvoip.gyp
@@ -382,7 +382,7 @@
                 'WEBRTC_POSIX',
               ],
               'conditions': [
-                [ '"<!(uname -p)" == "x86_64" or "<!(uname -p)" == "i686"', {
+                [ '"<!(uname -m)" == "x86_64" or "<!(uname -m)" == "i686"', {
                   'cflags_cc': [
                     '-msse2',
                   ],

--- a/libtgvoip.gyp
+++ b/libtgvoip.gyp
@@ -382,7 +382,7 @@
                 'WEBRTC_POSIX',
               ],
               'conditions': [
-                [ '"<!(uname -m)" == "x86_64" or "<!(uname -m)" == "i686"', {
+                [ '"<!(uname -m)" == "i686"', {
                   'cflags_cc': [
                     '-msse2',
                   ],


### PR DESCRIPTION
Without this libtgvoip won't compile in ARM CPUs. 

Fixes #28 