### PR TITLE
Fixed build under GCC 8.2.1. Added missing includes

### DIFF
--- a/VoIPController.cpp
+++ b/VoIPController.cpp
@@ -26,6 +26,7 @@
 #include <stdexcept>
 #include <algorithm>
 #include <inttypes.h>
+#include <cfloat>
 
 
 


### PR DESCRIPTION
Fixed build under GCC 8.2.1. Added missing includes.
Closes #50.