### PR TITLE
Pointer to ServerConfigImpl

### DIFF
--- a/VoIPServerConfig.cpp
+++ b/VoIPServerConfig.cpp
@@ -9,52 +9,61 @@
 #include "logging.h"
 #include <sstream>
 #include <locale>
+#include <utility>
+#include "threading.h"
+#include "json11.hpp"
 
 using namespace tgvoip;
 
-ServerConfig* ServerConfig::sharedInstance=NULL;
+namespace tgvoip {
+class ServerConfigImpl {
+public:
+	int32_t GetInt(std::string name, int32_t fallback);
+	double GetDouble(std::string name, double fallback);
+	std::string GetString(std::string name, std::string fallback);
+	bool GetBoolean(std::string name, bool fallback);
+	void Update(std::string jsonString);
 
-ServerConfig::ServerConfig(){
+private:
+	bool ContainsKey(std::string key);
+	json11::Json config;
+	Mutex mutex;
+};
 }
 
-ServerConfig::~ServerConfig(){
+namespace{
+ServerConfig* sharedInstance=NULL;
 }
 
-ServerConfig *ServerConfig::GetSharedInstance(){
-	if(!sharedInstance)
-		sharedInstance=new ServerConfig();
-	return sharedInstance;
-}
-
-bool ServerConfig::GetBoolean(std::string name, bool fallback){
+bool ServerConfigImpl::GetBoolean(std::string name, bool fallback){
 	MutexGuard sync(mutex);
 	if(ContainsKey(name) && config[name].is_bool())
 		return config[name].bool_value();
 	return fallback;
 }
 
-double ServerConfig::GetDouble(std::string name, double fallback){
+double ServerConfigImpl::GetDouble(std::string name, double fallback){
 	MutexGuard sync(mutex);
 	if(ContainsKey(name) && config[name].is_number())
 		return config[name].number_value();
 	return fallback;
 }
 
-int32_t ServerConfig::GetInt(std::string name, int32_t fallback){
+int32_t ServerConfigImpl::GetInt(std::string name, int32_t fallback){
 	MutexGuard sync(mutex);
 	if(ContainsKey(name) && config[name].is_number())
 		return config[name].int_value();
 	return fallback;
 }
 
-std::string ServerConfig::GetString(std::string name, std::string fallback){
+std::string ServerConfigImpl::GetString(std::string name, std::string fallback){
 	MutexGuard sync(mutex);
 	if(ContainsKey(name) && config[name].is_string())
 		return config[name].string_value();
 	return fallback;
 }
 
-void ServerConfig::Update(std::string jsonString){
+void ServerConfigImpl::Update(std::string jsonString){
 	MutexGuard sync(mutex);
 	LOGD("=== Updating voip config ===");
 	LOGD("%s", jsonString.c_str());
@@ -64,7 +73,39 @@ void ServerConfig::Update(std::string jsonString){
 		LOGE("Error parsing server config: %s", jsonError.c_str());
 }
 
-
-bool ServerConfig::ContainsKey(std::string key){
+bool ServerConfigImpl::ContainsKey(std::string key){
 	return config.object_items().find(key)!=config.object_items().end();
+}
+
+
+ServerConfig::ServerConfig() : p_impl(std::make_shared<ServerConfigImpl>()){
+}
+
+ServerConfig::~ServerConfig(){
+}
+
+ServerConfig* ServerConfig::GetSharedInstance(){
+	if(!sharedInstance)
+		sharedInstance=new ServerConfig();
+	return sharedInstance;
+}
+
+int32_t ServerConfig::GetInt(std::string name, int32_t fallback){
+	return p_impl->GetInt(std::move(name), fallback);
+}
+
+double ServerConfig::GetDouble(std::string name, double fallback){
+	return p_impl->GetDouble(std::move(name), fallback);
+}
+
+std::string ServerConfig::GetString(std::string name, std::string fallback){
+	return p_impl->GetString(std::move(name), fallback);
+}
+
+bool ServerConfig::GetBoolean(std::string name, bool fallback){
+	return p_impl->GetBoolean(std::move(name), fallback);
+}
+
+void ServerConfig::Update(std::string jsonString){
+	p_impl->Update(std::move(jsonString));
 }

--- a/VoIPServerConfig.h
+++ b/VoIPServerConfig.h
@@ -7,13 +7,13 @@
 #ifndef TGVOIP_VOIPSERVERCONFIG_H
 #define TGVOIP_VOIPSERVERCONFIG_H
 
-#include <map>
+#include <memory>
 #include <string>
 #include <stdint.h>
-#include "threading.h"
-#include "json11.hpp"
 
 namespace tgvoip{
+
+class ServerConfigImpl;
 
 class ServerConfig{
 public:
@@ -27,10 +27,7 @@ public:
 	void Update(std::string jsonString);
 
 private:
-	static ServerConfig* sharedInstance;
-	bool ContainsKey(std::string key);
-    json11::Json config;
-	Mutex mutex;
+	std::shared_ptr<ServerConfigImpl> p_impl;
 };
 }
 


### PR DESCRIPTION
 *  This is needed to avoid transitive dependency on third-party library for JSON parsing.
 *  The patch doesn't break backward compatibility of API.