### PR TITLE
GYP: Add missing 'iphlpapi' library to the list of libraries on Windows

### DIFF
--- a/libtgvoip.gyp
+++ b/libtgvoip.gyp
@@ -825,6 +825,7 @@
               'libraries': [
                 'winmm',
                 'ws2_32',
+                'iphlpapi',
                 'kernel32',
                 'user32',
               ],


### PR DESCRIPTION
This fixes compilation of `libtgvoip` outside of the [Telegram Desktop](https://github.com/telegramdesktop/tdesktop) project.

`libtgvoip` uses `GetAdaptersAddresses` function, which requires `iphlpapi` to be linked with.
Telegram Desktop specifies `iphlpapi` in the [telegramdesktop/tdesktop/Telegram/gyp/settings_win.gypi](https://github.com/telegramdesktop/tdesktop/blob/adf5c8ec71ce4a88ca41a61c008cc5ca8305425e/Telegram/gyp/settings_win.gypi#L68) file, so `libtgvoip` compiles fine only with it.