### PR TITLE
GYP: Add ability to link with CRT dynamically under Windows

### DIFF
--- a/libtgvoip.gyp
+++ b/libtgvoip.gyp
@@ -795,20 +795,20 @@
                     ],
                   },
                   'sources': [
-                   '<(tgvoip_src_loc)/os/darwin/TGVVideoRenderer.mm',
-                   '<(tgvoip_src_loc)/os/darwin/TGVVideoRenderer.h',
-                   '<(tgvoip_src_loc)/os/darwin/TGVVideoSource.mm',
-                   '<(tgvoip_src_loc)/os/darwin/TGVVideoSource.h',
-                   '<(tgvoip_src_loc)/os/darwin/VideoToolboxEncoderSource.mm',
-                   '<(tgvoip_src_loc)/os/darwin/VideoToolboxEncoderSource.h',
-                   '<(tgvoip_src_loc)/os/darwin/SampleBufferDisplayLayerRenderer.mm',
-                   '<(tgvoip_src_loc)/os/darwin/SampleBufferDisplayLayerRenderer.h',
+                    '<(tgvoip_src_loc)/os/darwin/TGVVideoRenderer.mm',
+                    '<(tgvoip_src_loc)/os/darwin/TGVVideoRenderer.h',
+                    '<(tgvoip_src_loc)/os/darwin/TGVVideoSource.mm',
+                    '<(tgvoip_src_loc)/os/darwin/TGVVideoSource.h',
+                    '<(tgvoip_src_loc)/os/darwin/VideoToolboxEncoderSource.mm',
+                    '<(tgvoip_src_loc)/os/darwin/VideoToolboxEncoderSource.h',
+                    '<(tgvoip_src_loc)/os/darwin/SampleBufferDisplayLayerRenderer.mm',
+                    '<(tgvoip_src_loc)/os/darwin/SampleBufferDisplayLayerRenderer.h',
                   ],
                 }],
                 ['"<(official_build_target)" == "macstore"', {
-                 'defines': [
-                  'TGVOIP_NO_OSX_PRIVATE_API',
-                 ],
+                  'defines': [
+                    'TGVOIP_NO_OSX_PRIVATE_API',
+                  ],
                 }],
               ],
             },
@@ -832,11 +832,11 @@
               'msvs_settings': {
                 'VCCLCompilerTool': {
                   'ProgramDataBaseFileName': '$(OutDir)\\$(ProjectName).pdb',
-                  'DebugInformationFormat': '3',          # Program Database (/Zi)
+                  'DebugInformationFormat': '3',  # Program Database (/Zi)
                   'AdditionalOptions': [
-                    '/MP',   # Enable multi process build.
-                    '/EHsc', # Catch C++ exceptions only, extern C functions never throw a C++ exception.
-                    '/wd4068', # Disable "warning C4068: unknown pragma"
+                    '/MP',      # Enable multi process build.
+                    '/EHsc',    # Catch C++ exceptions only, extern C functions never throw a C++ exception.
+                    '/wd4068',  # Disable "warning C4068: unknown pragma"
                   ],
                   'TreatWChar_tAsBuiltInType': 'false',
                 },
@@ -858,15 +858,15 @@
                   ],
                   'msvs_settings': {
                     'VCCLCompilerTool': {
-                      'Optimization': '0',                # Disabled (/Od)
-                      'RuntimeLibrary': '1',              # Multi-threaded Debug (/MTd)
+                      'Optimization': '0',        # Disabled (/Od)
+                      'RuntimeLibrary': '1',      # Multi-threaded Debug (/MTd)
                       'RuntimeTypeInfo': 'true',
                     },
                     'VCLibrarianTool': {
                       'AdditionalOptions': [
-                        '/NODEFAULTLIB:LIBCMT'
-                      ]
-                    }
+                        '/NODEFAULTLIB:LIBCMT',
+                      ],
+                    },
                   },
                 },
                 'Release': {
@@ -878,18 +878,18 @@
                   ],
                   'msvs_settings': {
                     'VCCLCompilerTool': {
-                      'Optimization': '2',                 # Maximize Speed (/O2)
-                      'InlineFunctionExpansion': '2',      # Any suitable (/Ob2)
-                      'EnableIntrinsicFunctions': 'true',  # Yes (/Oi)
-                      'FavorSizeOrSpeed': '1',             # Favor fast code (/Ot)
-                      'RuntimeLibrary': '0',               # Multi-threaded (/MT)
-                      'EnableEnhancedInstructionSet': '2', # Streaming SIMD Extensions 2 (/arch:SSE2)
-                      'WholeProgramOptimization': 'true',  # /GL
+                      'Optimization': '2',                  # Maximize Speed (/O2)
+                      'InlineFunctionExpansion': '2',       # Any suitable (/Ob2)
+                      'EnableIntrinsicFunctions': 'true',   # Yes (/Oi)
+                      'FavorSizeOrSpeed': '1',              # Favor fast code (/Ot)
+                      'RuntimeLibrary': '0',                # Multi-threaded (/MT)
+                      'EnableEnhancedInstructionSet': '2',  # Streaming SIMD Extensions 2 (/arch:SSE2)
+                      'WholeProgramOptimization': 'true',   # /GL
                     },
                     'VCLibrarianTool': {
                       'AdditionalOptions': [
                         '/LTCG',
-                      ]
+                      ],
                     },
                   },
                 },
@@ -907,7 +907,7 @@
                   'cflags_cc': [
                     '-msse2',
                   ],
-                }]
+                }],
               ],
               'direct_dependent_settings': {
                 'libraries': [
@@ -919,4 +919,4 @@
         ],
       },
     ],
-  }
+}

--- a/libtgvoip.gyp
+++ b/libtgvoip.gyp
@@ -15,6 +15,7 @@
           'tgvoip_src_loc': '.',
           'official_build_target%': '',
           'linux_path_opus_include%': '<(DEPTH)/../../../Libraries/opus/include',
+          'dynamic_msvc_runtime%': 0,
         },
         'include_dirs': [
           '<(tgvoip_src_loc)/webrtc_dsp',
@@ -859,8 +860,15 @@
                   'msvs_settings': {
                     'VCCLCompilerTool': {
                       'Optimization': '0',        # Disabled (/Od)
-                      'RuntimeLibrary': '1',      # Multi-threaded Debug (/MTd)
                       'RuntimeTypeInfo': 'true',
+
+                      'conditions': [
+                        [ '<(dynamic_msvc_runtime) == 0', {
+                          'RuntimeLibrary': 1,  # Multi-threaded Debug, static (/MTd)
+                        }, {
+                          'RuntimeLibrary': 3,  # Multi-threaded Debug, dynamic (/MDd)
+                        }],
+                      ],
                     },
                     'VCLibrarianTool': {
                       'AdditionalOptions': [
@@ -882,9 +890,16 @@
                       'InlineFunctionExpansion': '2',       # Any suitable (/Ob2)
                       'EnableIntrinsicFunctions': 'true',   # Yes (/Oi)
                       'FavorSizeOrSpeed': '1',              # Favor fast code (/Ot)
-                      'RuntimeLibrary': '0',                # Multi-threaded (/MT)
                       'EnableEnhancedInstructionSet': '2',  # Streaming SIMD Extensions 2 (/arch:SSE2)
                       'WholeProgramOptimization': 'true',   # /GL
+
+                      'conditions': [
+                        [ '<(dynamic_msvc_runtime) == 0', {
+                          'RuntimeLibrary': 0,  # Multi-threaded, static (/MT)
+                        }, {
+                          'RuntimeLibrary': 2,  # Multi-threaded, dynamic (/MD)
+                        }],
+                      ],
                     },
                     'VCLibrarianTool': {
                       'AdditionalOptions': [


### PR DESCRIPTION
This is required to link libtgvoip with the Python extension when compiling it by `distutils`.