### PR TITLE
Fix twice copying of NetworkAddress values in the Endpoint constructor

### DIFF
--- a/VoIPController.cpp
+++ b/VoIPController.cpp
@@ -3954,7 +3954,7 @@ Endpoint::Endpoint(int64_t id, uint16_t port, const IPv4Address& _address, const
 	udpPongCount=0;
 }
 
-Endpoint::Endpoint(int64_t id, uint16_t port, const NetworkAddress _address, const NetworkAddress _v6address, Type type, unsigned char peerTag[16]) : address(_address), v6address(_v6address){
+Endpoint::Endpoint(int64_t id, uint16_t port, const NetworkAddress& _address, const NetworkAddress& _v6address, Type type, unsigned char peerTag[16]) : address(_address), v6address(_v6address){
 	this->id=id;
 	this->port=port;
 	this->type=type;

--- a/VoIPController.h
+++ b/VoIPController.h
@@ -137,7 +137,7 @@ namespace tgvoip{
 		};
 
 		Endpoint(int64_t id, uint16_t port, const IPv4Address& address, const IPv6Address& v6address, Type type, unsigned char* peerTag);
-		Endpoint(int64_t id, uint16_t port, const NetworkAddress address, const NetworkAddress v6address, Type type, unsigned char* peerTag);
+		Endpoint(int64_t id, uint16_t port, const NetworkAddress& address, const NetworkAddress& v6address, Type type, unsigned char* peerTag);
 		Endpoint();
 		~Endpoint();
 		const NetworkAddress& GetAddress() const;


### PR DESCRIPTION
An excessive copying occurred when passing a value to the constructor, before copying it in the member initializer list.

This also (almost) fixes SWIG code generation for `VoIPController` source files.